### PR TITLE
Remove JS dependencies to avoid dependency error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,20 +6,20 @@ gem 'rails', '4.2.6'
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3'
 # Use SCSS for stylesheets
-gem 'sass-rails', '~> 5.0'
+#gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets
-gem 'uglifier', '>= 1.3.0'
+#gem 'uglifier', '>= 1.3.0'
 # Use CoffeeScript for .coffee assets and views
-gem 'coffee-rails', '~> 4.1.0'
+#gem 'coffee-rails', '~> 4.1.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
-# gem 'therubyracer', platforms: :ruby
+#gem 'therubyracer', platforms: :ruby
 
 # Use jquery as the JavaScript library
-gem 'jquery-rails'
+#gem 'jquery-rails'
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
-gem 'turbolinks'
+#gem 'turbolinks'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-gem 'jbuilder', '~> 2.0'
+#gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0', group: :doc
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,13 +72,6 @@ GEM
     childprocess (0.5.9)
       ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.1)
-    coffee-rails (4.1.1)
-      coffee-script (>= 2.2.0)
-      railties (>= 4.0.0, < 5.1.x)
-    coffee-script (2.4.1)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.10.0)
     concurrent-ruby (1.0.2)
     contracts (0.14.0)
     cucumber (2.3.3)
@@ -102,7 +95,6 @@ GEM
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     erubis (2.7.0)
-    execjs (2.7.0)
     factory_girl (4.7.0)
       activesupport (>= 3.0.0)
     faker (1.6.3)
@@ -115,13 +107,6 @@ GEM
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     i18n (0.7.0)
-    jbuilder (2.4.1)
-      activesupport (>= 3.0.0, < 5.1)
-      multi_json (~> 1.2)
-    jquery-rails (4.1.1)
-      rails-dom-testing (>= 1, < 3)
-      railties (>= 4.2.0)
-      thor (>= 0.14, < 2.0)
     json (1.8.3)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
@@ -209,13 +194,6 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
-    sass (3.4.22)
-    sass-rails (5.0.4)
-      railties (>= 4.0.0, < 5.0)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
@@ -232,18 +210,13 @@ GEM
     sqlite3 (1.3.11)
     thor (0.19.1)
     thread_safe (0.3.5)
-    tilt (2.0.4)
     trema (0.10.1)
       bundler (~> 1.11.2)
       gli (~> 2.13.4)
       phut (~> 0.7.7)
       pio (~> 0.30.0)
-    turbolinks (2.5.3)
-      coffee-rails
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    uglifier (3.0.0)
-      execjs (>= 0.3.0, < 3)
     unicode-display_width (1.0.5)
     web-console (2.3.0)
       activemodel (>= 4.0)
@@ -259,14 +232,11 @@ PLATFORMS
 DEPENDENCIES
   aruba
   byebug
-  coffee-rails (~> 4.1.0)
   cucumber-rails
   database_cleaner
   factory_girl
   faker
   gli
-  jbuilder (~> 2.0)
-  jquery-rails
   phut!
   pio
   rails (= 4.2.6)
@@ -274,13 +244,10 @@ DEPENDENCIES
   rspec-given
   rspec-rails
   rubocop
-  sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   spring
   sqlite3
   trema
-  turbolinks
-  uglifier (>= 1.3.0)
   web-console (~> 2.0)
 
 BUNDLED WITH


### PR DESCRIPTION
NodeJSが導入されていない開発環境でエラーになることを避けるため、Javascriptに関連した依存関係を削除しました。