### PR TITLE
Add NetTester::Command.add_host API

### DIFF
--- a/bin/net_tester
+++ b/bin/net_tester
@@ -45,13 +45,13 @@ module NetTester
       c.flag [:D, :dpid]
 
       c.action do |_global_options, options, _args|
-        raise '--nhost option is mandatory' if options[:nhost].nil?
         raise '--device option is mandatory' if options[:device].nil?
         raise '--dpid option is mandatory' if options[:dpid].nil?
-        exit_now!('--nhost must be > 0') if options[:nhost].to_i <= 0
+        exit_now!('--nhost must be > 0') if options[:nhost] && options[:nhost].to_i <= 0
         exit_now!('NetTester is already running') if Command.running?
 
-        Command.run options[:nhost].to_i, options[:dpid].hex, options[:vlan]
+        Command.run options[:dpid].hex, options[:vlan]
+        Command.add_host options[:nhost].to_i if options[:nhost]
         Command.connect_switch(device: options[:device], port_number: options[:nhost].to_i + 1)
       end
     end
@@ -76,9 +76,7 @@ module NetTester
         if options[:port].to_i > Vhost.all.size
           exit_now!("#{options[:port]}: no such port")
         end
-        if options[:port].to_i < 0
-          exit_now!("#{options[:port]}: invalid port")
-        end
+        exit_now!("#{options[:port]}: invalid port") if options[:port].to_i < 0
 
         Command.add options[:vport].to_i, options[:port].to_i
       end
@@ -103,9 +101,7 @@ module NetTester
         if options[:port].to_i > Vhost.all.size
           exit_now!("#{options[:port]}: no such port")
         end
-        if options[:port].to_i < 0
-          exit_now!("#{options[:port]}: invalid port")
-        end
+        exit_now!("#{options[:port]}: invalid port") if options[:port].to_i < 0
 
         Command.delete options[:vport].to_i, options[:port].to_i
       end
@@ -140,9 +136,7 @@ module NetTester
         exit_now!('NetTester is not running') unless Command.running?
         help_now!('host is required') if args.empty?
         host = args.first
-        unless Vhost.find_by(name: host)
-          exit_now! %(#{host}: no such host)
-        end
+        exit_now! %(#{host}: no such host) unless Vhost.find_by(name: host)
 
         sent_desc = ''
         Vhost.all.each do |each|

--- a/features/step_definitions/internal_test_steps.rb
+++ b/features/step_definitions/internal_test_steps.rb
@@ -7,7 +7,8 @@ end
 
 Given(/^NetTester でテストホスト (\d+) 台を起動$/) do |nhost|
   raise 'NetTester 物理スイッチが起動していない' unless @physical_test_switch_dpid
-  NetTester::Command.run nhost.to_i, @physical_test_switch_dpid
+  NetTester::Command.run @physical_test_switch_dpid
+  NetTester::Command.add_host nhost.to_i
   sleep 1
 end
 
@@ -15,7 +16,8 @@ Given(/^NetTester と VLAN を有効にしたテストホスト (\d+) 台を起�
   vlan_option = + table.hashes.map do |each|
     "host#{each['Host']}:#{each['VLAN ID']}"
   end.join(',')
-  NetTester::Command.run nhost.to_i, @physical_test_switch_dpid, vlan_option
+  NetTester::Command.run @physical_test_switch_dpid, vlan_option
+  NetTester::Command.add_host nhost.to_i
   sleep 1
 end
 

--- a/lib/net_tester/command.rb
+++ b/lib/net_tester/command.rb
@@ -14,14 +14,17 @@ module NetTester
   module Command
     extend Phut::ShellRunner
 
-    def self.run(nhost, dpid, vlan = '')
+    def self.run(dpid, vlan = '')
       controller_file = File.expand_path File.join(__dir__, 'controller.rb')
       sh "bundle exec trema run #{controller_file} -L #{File.expand_path Phut.log_dir} -P #{File.expand_path Phut.pid_dir} -S #{File.expand_path Phut.socket_dir} --daemon -- #{dpid} #{vlan}"
       @@test_switch = TestSwitch.create(dpid: 0xdad1c001)
+    end
 
+    def self.add_host(nhost)
       ip_address = Array.new(nhost) { Faker::Internet.ip_v4_address }
       mac_address = Array.new(nhost) { Faker::Internet.mac_address }
       arp_entries = ip_address.zip(mac_address).map { |each| each.join('/') }.join(',')
+
       1.upto(nhost).each do |each|
         host_name = "host#{each}"
         port_name = "port#{each}"


### PR DESCRIPTION
`net_tester run` を `--nhost` オプションなしで起動できるようにする (あとからホストを追加したい)
yasuhito/ool_nettester#6